### PR TITLE
Remove presenter creation code from views

### DIFF
--- a/androidapp/src/main/java/cat/helm/android/MainActivity.kt
+++ b/androidapp/src/main/java/cat/helm/android/MainActivity.kt
@@ -1,54 +1,29 @@
 package cat.helm.android
 
 import android.os.Bundle
-import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
-import cat.helm.common.showlist.data.network.ApiConstants
-import cat.helm.common.showlist.data.tvshow.TvShowApiDataSource
-import cat.helm.common.showlist.data.tvshow.TvShowCacheDatasource
-import cat.helm.common.showlist.data.tvshow.TvShowDataRepository
-import cat.helm.common.showlist.domain.ShowListFeature
 import cat.helm.common.showlist.domain.State
-import cat.helm.common.showlist.domain.usecase.GetShows
-import cat.helm.common.showlist.view.ShowListPresenter
+import cat.helm.common.showlist.view.ShowListPresenterFactory
 import cat.helm.common.showlist.view.ShowListView
-import io.ktor.client.HttpClient
-import io.ktor.client.features.defaultRequest
-import io.ktor.client.request.host
-import io.ktor.http.URLProtocol
 import kotlinx.android.synthetic.main.activity_main.*
-import io.ktor.client.features.json.JsonFeature
-import io.ktor.client.features.json.serializer.KotlinxSerializer
 import kotlinx.android.synthetic.main.activity_tv_show.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
 class MainActivity : AppCompatActivity(), ShowListView {
     lateinit var adapter: TvShowAdapter
-
+    @FlowPreview
+    @ExperimentalCoroutinesApi
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_tv_show)
         setSupportActionBar(toolbar)
         adapter = TvShowAdapter()
 
-        val presenter = ShowListPresenter(this, ShowListFeature(GetShows(TvShowDataRepository(TvShowApiDataSource(
-            HttpClient().config {
-                defaultRequest {
-                    host = ApiConstants.BASE_URL
-                    url {
-                        protocol = URLProtocol.HTTPS
-                        parameters["api_key"] = ApiConstants.API_KEY
-                    }
-                }
-                install(JsonFeature) {
-                    serializer = KotlinxSerializer()
-                }
-            }
-        ),
-            TvShowCacheDatasource()
-        ))))
+        val presenter = ShowListPresenterFactory.create(this)
 
         // fab.setOnClickListener {
         presenter.doIntent(ShowListView.UserIntent.GetShowList)

--- a/androidapp/src/main/java/cat/helm/android/MainActivity.kt
+++ b/androidapp/src/main/java/cat/helm/android/MainActivity.kt
@@ -23,7 +23,7 @@ class MainActivity : AppCompatActivity(), ShowListView {
         setSupportActionBar(toolbar)
         adapter = TvShowAdapter()
 
-        val presenter = ShowListPresenterFactory.create(this)
+        val presenter = ShowListPresenterFactory.create()
 
         // fab.setOnClickListener {
         presenter.doIntent(ShowListView.UserIntent.GetShowList)

--- a/common/src/commonMain/kotlin/cat.helm.common/showlist/data/tvshow/TvShowApiDataSource.kt
+++ b/common/src/commonMain/kotlin/cat.helm.common/showlist/data/tvshow/TvShowApiDataSource.kt
@@ -5,12 +5,20 @@ import cat.helm.common.showlist.data.entity.TvShowDataEntity
 import cat.helm.common.showlist.data.network.ApiConstants
 import cat.helm.common.showlist.data.network.handleResponse
 import io.ktor.client.HttpClient
+import io.ktor.client.features.defaultRequest
+import io.ktor.client.features.json.JsonFeature
+import io.ktor.client.features.json.serializer.KotlinxSerializer
 import io.ktor.client.request.get
+import io.ktor.client.request.host
 import io.ktor.client.response.HttpResponse
+import io.ktor.http.URLProtocol
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.serialization.UnstableDefault
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonConfiguration
@@ -18,6 +26,7 @@ import kotlinx.serialization.list
 
 class TvShowApiDataSource(private val client: HttpClient) {
 
+    @ExperimentalCoroutinesApi
     fun getShows(): Flow<Result<List<TvShowDataEntity>, Exception>> =
         flow<Result<List<TvShowDataEntity>, Exception>> {
             val json = Json(JsonConfiguration.Stable.copy(strictMode = false))
@@ -31,6 +40,7 @@ class TvShowApiDataSource(private val client: HttpClient) {
             })
         }.flowOn(Dispatchers.Unconfined)
 
+    @UnstableDefault
     suspend fun getShowById(showId: Int): Result<TvShowDataEntity, Exception> {
         val response = client.get<HttpResponse> {
             url {
@@ -43,5 +53,26 @@ class TvShowApiDataSource(private val client: HttpClient) {
                 Json.nonstrict.parse(TvShowDataEntity.serializer(), responseBody)
             }
         }
+    }
+}
+
+object TvShowApiDataSourceFactory {
+    @FlowPreview
+    @ExperimentalCoroutinesApi
+    fun create(): TvShowApiDataSource {
+        return TvShowApiDataSource(
+            HttpClient().config {
+                defaultRequest {
+                    host = ApiConstants.BASE_URL
+                    url {
+                        protocol = URLProtocol.HTTPS
+                        parameters["api_key"] = ApiConstants.API_KEY
+                    }
+                }
+                install(JsonFeature) {
+                    serializer = KotlinxSerializer()
+                }
+            }
+        )
     }
 }

--- a/common/src/commonMain/kotlin/cat.helm.common/showlist/data/tvshow/TvShowCacheDatasource.kt
+++ b/common/src/commonMain/kotlin/cat.helm.common/showlist/data/tvshow/TvShowCacheDatasource.kt
@@ -15,3 +15,9 @@ class TvShowCacheDatasource {
         tvShowList.find { it.id == showId }
     }
 }
+
+object TvShowCacheDatasourceFactory {
+    fun create(): TvShowCacheDatasource {
+        return TvShowCacheDatasource()
+    }
+}

--- a/common/src/commonMain/kotlin/cat.helm.common/showlist/data/tvshow/TvShowDataRepository.kt
+++ b/common/src/commonMain/kotlin/cat.helm.common/showlist/data/tvshow/TvShowDataRepository.kt
@@ -5,6 +5,7 @@ import cat.helm.common.showlist.data.entity.mapper.mapToTvShow
 import cat.helm.common.showlist.domain.TvShowRepository
 import cat.helm.common.showlist.domain.model.TvShow
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -16,4 +17,12 @@ class TvShowDataRepository(
 
     override  fun getShows(): Flow<Result<List<TvShow>, Exception>> =
         tvShowApiDataSource.getShows().map { it.map { it.map { it.mapToTvShow() } } }
+}
+
+object TvShowDataRepositoryFactory {
+    @FlowPreview
+    @ExperimentalCoroutinesApi
+    fun create(): TvShowDataRepository {
+        return TvShowDataRepository(TvShowApiDataSourceFactory.create(), TvShowCacheDatasourceFactory.create())
+    }
 }

--- a/common/src/commonMain/kotlin/cat.helm.common/showlist/domain/ShowListFeature.kt
+++ b/common/src/commonMain/kotlin/cat.helm.common/showlist/domain/ShowListFeature.kt
@@ -1,8 +1,11 @@
 package cat.helm.common.showlist.domain
 
 import cat.helm.common.showlist.domain.usecase.GetShows
+import cat.helm.common.showlist.domain.usecase.GetShowsFactory
 import cat.helm.common.showlist.view.ShowListView
-import kotlinx.coroutines.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.channels.ConflatedBroadcastChannel
 import kotlinx.coroutines.flow.*
 import kotlin.properties.Delegates
@@ -44,5 +47,13 @@ class ShowListFeature(val getShows: GetShows) {
                 println("pastel")
             }
             .launchIn(MainScope())
+    }
+}
+
+object ShowListFeatureFactory {
+    @FlowPreview
+    @ExperimentalCoroutinesApi
+    fun create(): ShowListFeature {
+        return ShowListFeature(GetShowsFactory.create())
     }
 }

--- a/common/src/commonMain/kotlin/cat.helm.common/showlist/domain/usecase/GetShows.kt
+++ b/common/src/commonMain/kotlin/cat.helm.common/showlist/domain/usecase/GetShows.kt
@@ -1,10 +1,21 @@
 package cat.helm.common.showlist.domain.usecase
 
 import cat.helm.common.showlist.Result
+import cat.helm.common.showlist.data.tvshow.TvShowDataRepositoryFactory
 import cat.helm.common.showlist.domain.TvShowRepository
 import cat.helm.common.showlist.domain.model.TvShow
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 
 class GetShows(private val tvShowRepository: TvShowRepository) {
     operator fun invoke(): Flow<Result<List<TvShow>, Exception>> = tvShowRepository.getShows()
+}
+
+object GetShowsFactory {
+    @FlowPreview
+    @ExperimentalCoroutinesApi
+    fun create(): GetShows {
+        return GetShows(TvShowDataRepositoryFactory.create())
+    }
 }

--- a/common/src/commonMain/kotlin/cat.helm.common/showlist/view/ShowListPresenter.kt
+++ b/common/src/commonMain/kotlin/cat.helm.common/showlist/view/ShowListPresenter.kt
@@ -1,11 +1,9 @@
 package cat.helm.common.showlist.view
 
 import cat.helm.common.showlist.domain.ShowListFeature
+import cat.helm.common.showlist.domain.ShowListFeatureFactory
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 
 @FlowPreview
 @ExperimentalCoroutinesApi
@@ -15,5 +13,13 @@ class ShowListPresenter(view: ShowListView, private val feature: ShowListFeature
 
     fun doIntent(userIntent: ShowListView.UserIntent) {
         feature.doIntent(userIntent)
+    }
+}
+
+object ShowListPresenterFactory {
+    @FlowPreview
+    @ExperimentalCoroutinesApi
+    fun create(view: ShowListView): ShowListPresenter {
+        return ShowListPresenter(view, ShowListFeatureFactory.create())
     }
 }

--- a/common/src/commonMain/kotlin/cat.helm.common/showlist/view/ShowListPresenter.kt
+++ b/common/src/commonMain/kotlin/cat.helm.common/showlist/view/ShowListPresenter.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.FlowPreview
 
 @FlowPreview
 @ExperimentalCoroutinesApi
-class ShowListPresenter(view: ShowListView, private val feature: ShowListFeature) {
+class ShowListPresenter(private val feature: ShowListFeature) {
 
     val state = feature.state
 
@@ -19,7 +19,7 @@ class ShowListPresenter(view: ShowListView, private val feature: ShowListFeature
 object ShowListPresenterFactory {
     @FlowPreview
     @ExperimentalCoroutinesApi
-    fun create(view: ShowListView): ShowListPresenter {
-        return ShowListPresenter(view, ShowListFeatureFactory.create())
+    fun create(): ShowListPresenter {
+        return ShowListPresenter(ShowListFeatureFactory.create())
     }
 }

--- a/web/src/main/kotlin/VideoList.kt
+++ b/web/src/main/kotlin/VideoList.kt
@@ -40,7 +40,7 @@ interface VideoListState : RState, ShowListView {
 class VideoList() : RComponent<RProps, VideoListState>() {
 
     override fun VideoListState.init() {
-        val presenter =  ShowListPresenterFactory.create(this)
+        val presenter =  ShowListPresenterFactory.create()
 
         presenter.doIntent(ShowListView.UserIntent.GetShowList)
         presenter.state.onEach {

--- a/web/src/main/kotlin/VideoList.kt
+++ b/web/src/main/kotlin/VideoList.kt
@@ -40,22 +40,8 @@ interface VideoListState : RState, ShowListView {
 class VideoList() : RComponent<RProps, VideoListState>() {
 
     override fun VideoListState.init() {
-        val presenter = ShowListPresenter(this, ShowListFeature(GetShows(TvShowDataRepository(TvShowApiDataSource(
-            HttpClient().config {
-                defaultRequest {
-                    host = ApiConstants.BASE_URL
-                    url {
-                        protocol = URLProtocol.HTTPS
-                        parameters["api_key"] = ApiConstants.API_KEY
-                    }
-                }
-                install(JsonFeature) {
-                    serializer = KotlinxSerializer()
-                }
-            }
-        ),
-            TvShowCacheDatasource()
-        ))))
+        val presenter =  ShowListPresenterFactory.create(this)
+
         presenter.doIntent(ShowListView.UserIntent.GetShowList)
         presenter.state.onEach {
             setState {


### PR DESCRIPTION
IMHO Views shall not know anything about Repositories, or data sources, because of this in this PR there is a couple of factories to move the creation responsibility outside of the views.